### PR TITLE
Comment out dns_keyfile config

### DIFF
--- a/templates/dns_nsupdate.yml.erb
+++ b/templates/dns_nsupdate.yml.erb
@@ -3,6 +3,6 @@
 # Configuration file for 'nsupdate' dns provider
 #
 
-:dns_key: <%= scope.lookupvar("foreman_proxy::keyfile") %>
+<%= '#'  if [nil, :undefined, :undef, ''].include?(scope.lookupvar("foreman_proxy::keyfile")) %>:dns_key: <%= scope.lookupvar("foreman_proxy::keyfile") %>
 # use this setting if you are managing a dns server which is not localhost though this proxy
 :dns_server: <%= scope.lookupvar("foreman_proxy::dns_server") %>


### PR DESCRIPTION
When there is no dns keyfile value comment out this in the config so that
the nsupdate script does not include a -k flag. This is an issue
when the smart proxy is trying to update a windows 2012 AD server.
