### PR TITLE
Changing from '' to 'disabled' because the OT rubocop doesn't like

### DIFF
--- a/templates/dns_nsupdate.yml.erb
+++ b/templates/dns_nsupdate.yml.erb
@@ -3,6 +3,6 @@
 # Configuration file for 'nsupdate' dns provider
 #
 
-<%= '#'  if [nil, :undefined, :undef, ''].include?(scope.lookupvar("foreman_proxy::keyfile")) %>:dns_key: <%= scope.lookupvar("foreman_proxy::keyfile") %>
+<%= '#'  if [nil, :undefined, :undef, 'disabled'].include?(scope.lookupvar("foreman_proxy::keyfile")) %>:dns_key: <%= scope.lookupvar("foreman_proxy::keyfile") %>
 # use this setting if you are managing a dns server which is not localhost though this proxy
 :dns_server: <%= scope.lookupvar("foreman_proxy::dns_server") %>


### PR DESCRIPTION
empty string being used.  This addition is temporary until we can
remove the 2003 AD otsql servers from the london network.
